### PR TITLE
Use configurable GPIO setup in web app

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,14 +3,18 @@ from flask import Flask, render_template, request, jsonify
 from config_loader import ConfigLoader
 from sensor_reader import SensorReader
 from actuator_manager import ActuatorManager
-from gpio_setup import setup_gpio, cleanup_gpio
+from gpio_setup import inicializar_gpio, limpiar_gpio
 
 app = Flask(__name__)
 
 # ✅ Inicializar configuración, sensores y actuadores
-setup_gpio()
 config = ConfigLoader()
 config.cargar_configuracion()
+
+# Configurar GPIO según el modo especificado en la configuración (por defecto BOARD)
+modo_gpio = config.obtener("general.modo_gpio", "BOARD")
+inicializar_gpio(modo_gpio)
+
 sensor_reader = SensorReader(config)
 actuator_manager = ActuatorManager(config)
 
@@ -49,4 +53,4 @@ if __name__ == "__main__":
     try:
         app.run(host="0.0.0.0", port=5000, debug=True)
     finally:
-        cleanup_gpio()
+        limpiar_gpio()


### PR DESCRIPTION
## Summary
- Initialize GPIO using new functions and configuration-based mode
- Clean up GPIO resources on shutdown

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'RPi')*

------
https://chatgpt.com/codex/tasks/task_e_689f636474908325b1f8425c1ba69988