### PR TITLE
Refactor actuator status to return state

### DIFF
--- a/actuator_manager.py
+++ b/actuator_manager.py
@@ -40,10 +40,8 @@ class ActuatorManager:
             print(f"❌ Actuador '{nombre}' no encontrado.")
 
     def status(self):
-        print("📋 Estado de actuadores:")
-        for nombre, activo in self.estado.items():
-            estado_str = "ON" if activo else "OFF"
-            print(f"  - {nombre}: {estado_str}")
+        """Retorna el estado actual de los actuadores."""
+        return self.estado
 
     def cleanup(self):
         print("♻️ Liberando GPIO...")

--- a/app.py
+++ b/app.py
@@ -38,8 +38,13 @@ def controlar_actuador(nombre, accion):
 
 @app.route("/actuadores/estado")
 def estado_actuadores():
-    # 📢 Devuelve estados de los actuadores
-    return jsonify(actuator_manager.status())
+    # 📢 Devuelve y muestra estados de los actuadores
+    estados = actuator_manager.status()
+    print("📋 Estado de actuadores:")
+    for nombre, activo in estados.items():
+        estado_str = "ON" if activo else "OFF"
+        print(f"  - {nombre}: {estado_str}")
+    return jsonify(estados)
 
 @app.errorhandler(404)
 def not_found(error):


### PR DESCRIPTION
## Summary
- Return relay state without printing in `ActuatorManager.status`
- Print actuator status in `estado_actuadores` route before returning JSON

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'RPi')*

------
https://chatgpt.com/codex/tasks/task_e_689f6aabab1c8325aa349ec317b083fb