### PR TITLE
Handle CO₂ PWM read errors gracefully

### DIFF
--- a/Sensores/co2_pwm_sensor.py
+++ b/Sensores/co2_pwm_sensor.py
@@ -23,4 +23,4 @@ class CO2PWMSensor:
             return {"co2": co2_ppm}
         except Exception as e:
             print(f"⚠️ Error leyendo CO₂ por PWM: {e}")
-            return {"co2": None}
+            return None

--- a/sensor_reader.py
+++ b/sensor_reader.py
@@ -28,7 +28,7 @@ class SensorReader:
                 if self.co2_pwm is None:
                     self.co2_pwm = CO2PWMSensor(pin)
                 lectura = self.co2_pwm.read()
-                if lectura:
+                if lectura is not None:
                     datos[nombre] = {
                         "co2": lectura["co2"]
                     }


### PR DESCRIPTION
## Summary
- Return `None` from `CO2PWMSensor.read` when PWM reading fails
- Treat missing CO₂ PWM readings explicitly in `SensorReader.read_all_sensors`

## Testing
- `python -m py_compile Sensores/co2_pwm_sensor.py sensor_reader.py`
- `pytest` *(fails: No module named 'RPi', 'Adafruit_DHT', 'serial')*


------
https://chatgpt.com/codex/tasks/task_e_689f6aab9e6c8325907d08e3561acaf2