### PR TITLE
Align API routes and fix stylesheet link

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,12 +19,12 @@ def index():
     # 🔑 Enviar lista de actuadores (corrigido relay_pins.keys())
     return render_template("index.html", actuadores=actuator_manager.relay_pins.keys())
 
-@app.route("/sensores")
+@app.route("/api/lecturas")
 def get_sensores():
     datos = sensor_reader.read_all()
     return jsonify(datos)
 
-@app.route("/actuador/<nombre>/<accion>", methods=["POST"])
+@app.route("/api/actuadores/<nombre>/<accion>", methods=["POST"])
 def controlar_actuador(nombre, accion):
     if accion == "on":
         actuator_manager.turn_on(nombre)
@@ -36,7 +36,7 @@ def controlar_actuador(nombre, accion):
         estado = "comando desconocido"
     return jsonify({"actuador": nombre, "accion": accion, "estado": estado})
 
-@app.route("/actuadores/estado")
+@app.route("/api/actuadores/estado")
 def estado_actuadores():
     # 📢 Devuelve estados de los actuadores
     return jsonify(actuator_manager.status())

--- a/static/script.js
+++ b/static/script.js
@@ -1,6 +1,6 @@
 async function actualizarSensores() {
     try {
-        const response = await fetch("/api/sensores");
+        const response = await fetch("/api/lecturas");
         const datos = await response.json();
 
         document.getElementById("temp").textContent = datos.temperatura_humedad.temperature || "--";
@@ -13,10 +13,8 @@ async function actualizarSensores() {
 
 async function toggleActuador(actuador, accion) {
     try {
-        await fetch(`/api/actuadores/${actuador}`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ accion })
+        await fetch(`/api/actuadores/${actuador}/${accion}`, {
+            method: "POST"
         });
     } catch (error) {
         console.error("Error cambiando actuador:", error);

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>🌱 Control Climático Futurista</title>
     <script src="https://cdn.jsdelivr.net/npm/@bernii/gauge.js/dist/gauge.min.js"></script>
-    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <style>
         body {
             background: linear-gradient(to right, #2c5364, #203a43, #0f2027);


### PR DESCRIPTION
## Summary
- Rename sensor and actuator endpoints under `/api` and update JS references
- Correct stylesheet reference in index template

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement RPi.GPIO)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'RPi')*

------
https://chatgpt.com/codex/tasks/task_e_689f6aa83cb08325abd1165cb62d48cb