### PR TITLE
Align manual mode constructor and add actuator name adapters

### DIFF
--- a/Actuadores/relay.py
+++ b/Actuadores/relay.py
@@ -45,6 +45,10 @@ class RelayBoard:
         GPIO.output(self.relay_pins[canal], GPIO.LOW)
         print(f"🔌 Relé {canal} desactivado (pin físico {self.relay_pins[canal]})")
 
+    # Adaptadores con nombres en inglés
+    turn_on = activar
+    turn_off = desactivar
+
     def apagar_todos(self):
         """Apaga todos los relés."""
         print("🔌 Apagando todos los relés...")

--- a/actuator_manager.py
+++ b/actuator_manager.py
@@ -39,6 +39,10 @@ class ActuatorManager:
         else:
             print(f"❌ Actuador '{nombre}' no encontrado.")
 
+    # Adaptadores para compatibilidad con nombres en español
+    activar = turn_on
+    desactivar = turn_off
+
     def status(self):
         print("📋 Estado de actuadores:")
         for nombre, activo in self.estado.items():

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ try:
     modo = input("Selecciona el modo (manual/automatico): ").strip().lower()
 
     if modo == "manual":
-        manual_mode = ManualMode(sensor_reader, actuator_manager)
+        manual_mode = ManualMode(actuator_manager, sensor_reader)
         manual_mode.run()
 
     elif modo == "automatico":

--- a/modos/manual_mode.py
+++ b/modos/manual_mode.py
@@ -33,10 +33,10 @@ class ManualMode:
                     self.mostrar_estado_sensores()
                 elif comando.startswith("on "):
                     dispositivo = comando[3:].strip()
-                    self.actuator_manager.activar(dispositivo)
+                    self.actuator_manager.turn_on(dispositivo)
                 elif comando.startswith("off "):
                     dispositivo = comando[4:].strip()
-                    self.actuator_manager.desactivar(dispositivo)
+                    self.actuator_manager.turn_off(dispositivo)
                 else:
                     print("❓ Comando no reconocido.")
                 self.mostrar_estado_sensores()


### PR DESCRIPTION
## Summary
- Fix ManualMode usage in `main.py`
- Switch manual mode to `turn_on`/`turn_off`
- Provide Spanish name adapters for actuators

## Testing
- `pytest` *(fails: No module named 'RPi')*


------
https://chatgpt.com/codex/tasks/task_e_689f6362e44083258a033c321961b4e1