### PR TITLE
Reorder ManualMode initialization parameters

### DIFF
--- a/modos/manual_mode.py
+++ b/modos/manual_mode.py
@@ -1,9 +1,9 @@
 # modos/manual_mode.py
 
 class ManualMode:
-    def __init__(self, actuator_manager, sensor_reader):
-        self.actuator_manager = actuator_manager
+    def __init__(self, sensor_reader, actuator_manager):
         self.sensor_reader = sensor_reader
+        self.actuator_manager = actuator_manager
 
     def mostrar_estado_sensores(self):
         print("📊 Sensores:")


### PR DESCRIPTION
## Summary
- Reorder ManualMode constructor to accept sensor reader before actuator manager
- Ensure main module instantiates ManualMode using the updated parameter order

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'RPi')*

------
https://chatgpt.com/codex/tasks/task_e_689fb5f5cdbc8325b0609f7c2ed590fd